### PR TITLE
FIX: Change payment approval message to state 5 minutes and not 5 days

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -58,7 +58,7 @@
   "store/warnings.delivery.time": "The delivery period starts to count from the moment your payment is confirmed.",
   "store/warnings.delivery.tracking": "A tracking code will be sent to your email when the delivery process begins.",
   "store/warnings.order.split": "Your purchase was split into {numOrders} orders as some of the items were sold by partners. But this does not affect shipping estimates.",
-  "store/warnings.payment.approval": "Payment approval may take from 5 minutes up to 5 business days.",
+  "store/warnings.payment.approval": "Payment approval may take 5 minutes.",
   "store/warnings.payment.bankInvoice.approval": "Payment approval for {paymentSystemName} may take up to 3 bussiness days. If payment is not due, your order will be automatically cancelled.",
   "store/warnings.payment.bankInvoice.value": "Please make a payment of {paymentValue} up to the due date according to the data below.",
   "store/warnings.payment.bankInvoice.value.duedate": "Please make a payment of {paymentValue} up to {paymentDueDate} according to the data below.",


### PR DESCRIPTION
### What problem is this solving?
TLF-1057 Change payment approval "warning" message

#### How it works
Messaging edited in en.json

#### How to test it?

[Workspace]()

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on
TLF-1057

#### How does this PR make you feel? :link:
![]()
