### PR TITLE
[WEB-248] - fix hasFurniture logic for order placed to correctly show furniture note

### DIFF
--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -4,6 +4,7 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useOrderGroup } from './components/OrderGroupContext'
 import { FurnitureNote } from './FurnitureNote'
+import { hasFurnitureDelivery } from './utils/functions'
 
 const CSS_HANDLES = ['confirmationMessage']
 
@@ -14,12 +15,7 @@ const ConfirmationMessage: FC = () => {
   const shippingMethod =
     orderGroup.orders[0].pickUpParcels.length > 0 ? 'collect' : 'deliver'
 
-  const shippingValue =
-    // eslint-disable-next-line prettier/prettier
-    orderGroup.orders[0].totals.find((item) => item.id === 'Shipping')?.value ??
-    0
-
-  const hasFurniture = orderGroup.orders[0].value > 50000 && shippingValue > 0
+  const hasFurniture = hasFurnitureDelivery(orderGroup)
 
   return (
     <div className={`${handles.confirmationContainer}`}>
@@ -52,7 +48,7 @@ const ConfirmationMessage: FC = () => {
           />
         )}
       </p>
-      {hasFurniture ? <FurnitureNote shippingMethod={shippingMethod} /> : null}
+      {hasFurniture && shippingMethod !== 'collect' ? <FurnitureNote shippingMethod={shippingMethod} /> : null}
     </div>
   )
 }

--- a/react/FurnitureNote.tsx
+++ b/react/FurnitureNote.tsx
@@ -13,28 +13,31 @@ const CSS_HANDLES = [
   'noteTitle',
 ]
 
-const deliveryMessage = `
-  we’ll call the recipient in the next few days to arrange the furniture
-  delivery.
-  <br/>
-  <br/>
-  Please ensure sufficient space to receive the goods and keep in
-  mind that the couriers can’t hoist goods onto balconies.
-  <br/>
-`
+const DeliveryMessage = () => (
+  <>
+    we’ll call the recipient in the next few days to arrange the furniture delivery.
+    <br />
+    <br />
+    Please ensure sufficient space to receive the goods and keep in mind that the couriers can’t hoist goods onto balconies.
+    <br />
+  </>
+)
 
-const collectMessage = `
-  We’ll call the recipient to book a collection time with the warehouse.
-`
+const CollectMessage = () => (
+  <>
+    We’ll call the recipient to book a collection time with the warehouse.
+  </>
+)
 
 export const FurnitureNote = ({ shippingMethod }: FurnitureNoteProps) => {
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <div className={`${handles.furnitureNote}`}>
-      <h4 className={`${handles.noteTitle}`}>Furniture delivery</h4>
-      {/* using dangerouslySetInnerHTML because the <br/> tags were not being added previously */}
-      <p dangerouslySetInnerHTML={{ __html: shippingMethod === 'deliver' ? deliveryMessage : collectMessage }} />
+    <div className={handles.furnitureNote}>
+      <h4 className={handles.noteTitle}>Furniture delivery</h4>
+      <p>
+        {shippingMethod === 'deliver' ? <DeliveryMessage /> : <CollectMessage />}
+      </p>
       <a href="https://help.bash.com/support/solutions" className={handles.noteLink}>
         Frequently asked questions
       </a>

--- a/react/FurnitureNote.tsx
+++ b/react/FurnitureNote.tsx
@@ -16,9 +16,11 @@ const CSS_HANDLES = [
 const deliveryMessage = `
   we’ll call the recipient in the next few days to arrange the furniture
   delivery.
-  <br /> Please ensure sufficient space to receive the goods and keep in
+  <br/>
+  <br/>
+  Please ensure sufficient space to receive the goods and keep in
   mind that the couriers can’t hoist goods onto balconies.
-  <br />
+  <br/>
 `
 
 const collectMessage = `
@@ -30,11 +32,9 @@ export const FurnitureNote = ({ shippingMethod }: FurnitureNoteProps) => {
 
   return (
     <div className={`${handles.furnitureNote}`}>
-      <h4 className={`${handles.noteTitle}`}>furniture delivery</h4>
-      <p>
-        {shippingMethod === 'deliver' ? deliveryMessage : collectMessage}
-        <br />{' '}
-      </p>
+      <h4 className={`${handles.noteTitle}`}>Furniture delivery</h4>
+      {/* using dangerouslySetInnerHTML because the <br/> tags were not being added previously */}
+      <p dangerouslySetInnerHTML={{ __html: shippingMethod === 'deliver' ? deliveryMessage : collectMessage }} />
       <a href="https://help.bash.com/support/solutions" className={handles.noteLink}>
         Frequently asked questions
       </a>

--- a/react/package.json
+++ b/react/package.json
@@ -24,21 +24,21 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "thefoschini.order-details": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.6/public/@types/thefoschini.order-details",
-    "thefoschini.order-placed": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.4/public/@types/thefoschini.order-placed",
+    "thefoschini.order-placed": "https://orderplaced--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.8+build1720120638/public/@types/thefoschini.order-placed",
     "typescript": "3.9.7",
-    "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.22.6/public/@types/vtex.address-form",
+    "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.3/public/@types/vtex.address-form",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.21.3/public/@types/vtex.flex-layout",
-    "vtex.order-placed-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.1/public/@types/vtex.order-placed-graphql",
+    "vtex.order-placed-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.4/public/@types/vtex.order-placed-graphql",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.9.0/public/@types/vtex.pixel-manager",
-    "vtex.profile-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.16.1/public/@types/vtex.profile-form",
+    "vtex.profile-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.17.0/public/@types/vtex.profile-form",
     "vtex.pwa-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.2/public/@types/vtex.render-runtime",
     "vtex.responsive-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-layout@0.1.4/public/@types/vtex.responsive-layout",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.2/public/@types/vtex.responsive-values",
-    "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.3/public/@types/vtex.shipping-estimate-translator",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources",
+    "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.3.0/public/@types/vtex.shipping-estimate-translator",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.96.0/public/@types/vtex.store-resources",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide",
-    "vtex.totalizer-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.5.0/public/@types/vtex.totalizer-translator"
+    "vtex.totalizer-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.6.1/public/@types/vtex.totalizer-translator"
   }
 }

--- a/react/utils/functions.ts
+++ b/react/utils/functions.ts
@@ -12,3 +12,27 @@ export const getEndpoints = (account: string): Endpoints => {
     clientsApiUrl: `${masterData}clients`,
   }
 }
+
+export function hasFurnitureDelivery(orderGroup: OrderGroup): boolean {
+  if (
+    !orderGroup ||
+    !orderGroup.orders ||
+    orderGroup.orders.length === 0 ||
+    orderGroup.orders[0].deliveryParcels.length === 0
+  ) {
+    return false;
+  }
+
+  const orders = orderGroup.orders;
+
+  for (let order of orders) {
+    if (
+      order.deliveryParcels &&
+      order.deliveryParcels.some(parcel => parcel && parcel.selectedSla === 'Furniture delivery')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4911,9 +4911,9 @@ test-exclude@^5.2.3:
   version "1.9.6"
   resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.6/public/@types/thefoschini.order-details#faa5c63e6f0b4303eac80d93d44356db554e850d"
 
-"thefoschini.order-placed@http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.4/public/@types/thefoschini.order-placed":
-  version "2.15.4"
-  resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.4/public/@types/thefoschini.order-placed#d0d352aa931904480584ea237e841f81013ab810"
+"thefoschini.order-placed@https://orderplaced--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.8+build1720120638/public/@types/thefoschini.order-placed":
+  version "2.15.8"
+  resolved "https://orderplaced--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.8+build1720120638/public/@types/thefoschini.order-placed#8c5ae5d8e4c00fa0987c4bb887431788c10d504f"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -5125,9 +5125,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.address-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.22.6/public/@types/vtex.address-form":
-  version "4.22.6"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.22.6/public/@types/vtex.address-form#c66292e32521e5fef1474d90f448a3b6e46ba683"
+"vtex.address-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.3/public/@types/vtex.address-form":
+  version "4.24.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.3/public/@types/vtex.address-form#001990f5774e8b2175d14536c01df3981356e2a2"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -5137,17 +5137,17 @@ verror@1.10.0:
   version "0.21.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.21.3/public/@types/vtex.flex-layout#407f0e310545ff006f08afb35f5d38ace4546435"
 
-"vtex.order-placed-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.1/public/@types/vtex.order-placed-graphql":
-  version "1.18.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.1/public/@types/vtex.order-placed-graphql#c79d100f4a76fc17511c169f3a891dfb575f558f"
+"vtex.order-placed-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.4/public/@types/vtex.order-placed-graphql":
+  version "1.18.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.18.4/public/@types/vtex.order-placed-graphql#bca28eaa25492fa43efc93545327e74fcb11fe39"
 
 "vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.9.0/public/@types/vtex.pixel-manager":
   version "1.9.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.9.0/public/@types/vtex.pixel-manager#eb61e263c4f8024430ef1a19d28bcf608db3d481"
 
-"vtex.profile-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.16.1/public/@types/vtex.profile-form":
-  version "3.16.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.16.1/public/@types/vtex.profile-form#0dea9a61e35e5c9ffe0c9bce6866b613d356aef7"
+"vtex.profile-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.17.0/public/@types/vtex.profile-form":
+  version "3.17.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.17.0/public/@types/vtex.profile-form#2fcbd86f2438a4602191c10c5f2667b5c4feaf44"
 
 "vtex.pwa-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components":
   version "0.4.1"
@@ -5165,21 +5165,21 @@ verror@1.10.0:
   version "0.4.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.2/public/@types/vtex.responsive-values#ba7b7a888e931be81d64e8348d99bd6310385ac9"
 
-"vtex.shipping-estimate-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.3/public/@types/vtex.shipping-estimate-translator":
-  version "2.2.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.3/public/@types/vtex.shipping-estimate-translator#56c520e45e61572c253542572c153eb1ad0f993f"
+"vtex.shipping-estimate-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.3.0/public/@types/vtex.shipping-estimate-translator":
+  version "2.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.3.0/public/@types/vtex.shipping-estimate-translator#47cd5baf775e33d3c623c56bbe223acca703faf7"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources":
-  version "0.93.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources#f7d82498aa2871d25df89c54f8fff2f5a7ac22f7"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.96.0/public/@types/vtex.store-resources":
+  version "0.96.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.96.0/public/@types/vtex.store-resources#6c281dd03ba28beeed38f4538c2068753d824f0d"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide":
   version "9.146.9"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.9/public/@types/vtex.styleguide#d1601fedfb665c6173334753171717da64e670bc"
 
-"vtex.totalizer-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.5.0/public/@types/vtex.totalizer-translator":
-  version "2.5.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.5.0/public/@types/vtex.totalizer-translator#ef262778630085a1f1a3b8a3de09267d069eb33f"
+"vtex.totalizer-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.6.1/public/@types/vtex.totalizer-translator":
+  version "2.6.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.6.1/public/@types/vtex.totalizer-translator#8be31be7db1a3768a1be55456dd9688b5a9b2109"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### What problem is this solving?

hasFurniture logic to show the furniture note on order placed is broken. 

#### How it works

- checks if any item in the order items array has the selectedSLA === "Furniture delivery"

#### How to test it?

[Workspace](https://orderplaced--thefoschini.myvtex.com/)

### Screenshots/Video example usage:
![Screenshot 2024-07-04 at 21 40 56](https://github.com/TFG-Labs/order-placed/assets/8531068/753a63af-a4c5-4536-b014-a7842f834a32)


### Related to / Depends on

#### How does this PR make you feel? :link:
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHYxY3BydHlxOGtjYmVxeHN2dDFyZnFuZ3oyeHp4cW9hN213bnBobSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SVH9y2LQUVVCRcqD7o/giphy.gif)
