### PR TITLE
hide order placed mini footer

### DIFF
--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react'
-import React, { useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { useIntl, defineMessages } from 'react-intl'
 import { Helmet, ExtensionPoint, useRuntime } from 'vtex.render-runtime'
@@ -36,11 +35,21 @@ const OrderPlaced: FC = () => {
   const runtime = useRuntime()
   const { settings = {} } = usePWA() || {}
   const [installDismissed, setInstallDismissed] = useState(false)
+  const [appCookie, setAppCookie] = useState<string | null>(null)
+
   const { data, loading, error } = useQuery<OrderGroupData>(GET_ORDER_GROUP, {
     variables: {
       orderGroup: runtime.query.og,
     },
   })
+
+  useEffect(() => {
+    const isAppCookie =
+      document.cookie
+        .match('(^|;)\\s*' + 'is_app' + '\\s*=\\s*([^;]+)')
+        ?.pop() ?? null
+    isAppCookie && setAppCookie(isAppCookie)
+  }, [])
 
   const { customerEmail, customerEmailLoading } = useGetCustomerEmail(
     data?.orderGroup.orders[0].clientProfileData.email
@@ -112,7 +121,7 @@ const OrderPlaced: FC = () => {
             )}
           </div>
 
-          <ExtensionPoint id="op-footer" />
+          {!appCookie && <ExtensionPoint id="op-footer" />}
         </div>
       </CurrencyContext.Provider>
     </OrderGroupContext.Provider>


### PR DESCRIPTION
#### What is the purpose of this pull request?
For App to avoid navigation using webView, the footer below total amount needs to be hidden.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
check that order-placed footer is hidden
[Workspace](https://bpf2897--thefoschini.myvtex.com/checkout/orderPlaced?og=B5979916)

#### Screenshots or example usage
<img width="1509" alt="Screenshot 2024-08-07 at 09 45 06" src="https://github.com/user-attachments/assets/d6ec8ab0-3245-4dda-a03e-1eeaf7036fcb">

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
