### PR TITLE
Add app links for continue shopping btn

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "thefoschiniqa",
+  "vendor": "thefoschini",
   "name": "order-placed",
   "version": "2.15.12",
   "title": "Order Placed",

--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -27,15 +27,12 @@ const ConfirmationMessage: FC = () => {
     if (typeof window === 'undefined') {
       return
     }
-    let redirectUrl
-    if (isApp) {
-      redirectUrl = window.location.hostname.includes('staging')
-        ? appHomeStaging
-        : appHomeProd
-    } else {
-      redirectUrl = 'https://bash.com'
-    }
 
+    const redirectUrl = window.location.hostname.includes('staging')
+      ? appHomeStaging
+      : appHomeProd
+    /* eslint no-console: ["error", { allow: ["log", "error"] }] */
+    console.log(redirectUrl)
     window.location.replace(redirectUrl)
   }
 

--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -5,8 +5,13 @@ import { useCssHandles } from 'vtex.css-handles'
 import { useOrderGroup } from './components/OrderGroupContext'
 import { FurnitureNote } from './FurnitureNote'
 import { getCookie, hasFurnitureDelivery } from './utils/functions'
+import { appHomeProd, appHomeStaging } from './utils'
 
-const CSS_HANDLES = ['confirmationMessage', 'continueShoppingButton', 'confirmationContainer']
+const CSS_HANDLES = [
+  'confirmationMessage',
+  'continueShoppingButton',
+  'confirmationContainer',
+]
 
 const ConfirmationMessage: FC = () => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -19,9 +24,19 @@ const ConfirmationMessage: FC = () => {
   }, [])
 
   const handleClick = () => {
-    if (typeof window !== 'undefined') {
-      window.location.replace('com.tfglabs.manhattan.beta://auth')
+    if (typeof window === 'undefined') {
+      return
     }
+    let redirectUrl
+    if (isApp) {
+      redirectUrl = window.location.hostname.includes('staging')
+        ? appHomeStaging
+        : appHomeProd
+    } else {
+      redirectUrl = 'https://bash.com'
+    }
+
+    window.location.replace(redirectUrl)
   }
 
   const shippingMethod =
@@ -31,41 +46,46 @@ const ConfirmationMessage: FC = () => {
 
   return (
     <div className={`${handles.confirmationContainer}`}>
-        <p
-          className={`${handles.confirmationMessage} mt5 t-body tc c-muted-1 lh-copy`}
-        >
-          {orderGroup.orders[0].clientProfileData.customerEmail ? (
-            <FormattedMessage
-              id="store/header.email"
-              values={{
-                lineBreak: <br />,
-                userEmail: (
-                  <strong className="nowrap">
-                    {orderGroup.orders[0].clientProfileData.customerEmail}
-                  </strong>
-                ),
-              }}
-            />
-          ) : (
-            <FormattedMessage
-              id="store/header.phone"
-              values={{
-                lineBreak: <br />,
-                phone: (
-                  <strong className="nowrap">
-                    {orderGroup.orders[0].clientProfileData.phone}
-                  </strong>
-                ),
-              }}
-            />
-          )}
-        </p>
-        {isApp && (
-          <button className={handles.continueShoppingButton} onClick={handleClick}>
-            Continue shopping
-          </button>
+      <p
+        className={`${handles.confirmationMessage} mt5 t-body tc c-muted-1 lh-copy`}
+      >
+        {orderGroup.orders[0].clientProfileData.customerEmail ? (
+          <FormattedMessage
+            id="store/header.email"
+            values={{
+              lineBreak: <br />,
+              userEmail: (
+                <strong className="nowrap">
+                  {orderGroup.orders[0].clientProfileData.customerEmail}
+                </strong>
+              ),
+            }}
+          />
+        ) : (
+          <FormattedMessage
+            id="store/header.phone"
+            values={{
+              lineBreak: <br />,
+              phone: (
+                <strong className="nowrap">
+                  {orderGroup.orders[0].clientProfileData.phone}
+                </strong>
+              ),
+            }}
+          />
         )}
-      {hasFurniture && shippingMethod !== 'collect' ? <FurnitureNote shippingMethod={shippingMethod} /> : null}
+      </p>
+      {isApp && (
+        <button
+          className={handles.continueShoppingButton}
+          onClick={handleClick}
+        >
+          Continue shopping
+        </button>
+      )}
+      {hasFurniture && shippingMethod !== 'collect' ? (
+        <FurnitureNote shippingMethod={shippingMethod} />
+      ) : null}
     </div>
   )
 }

--- a/react/utils/constants.ts
+++ b/react/utils/constants.ts
@@ -2,3 +2,5 @@ export const customPath = '/custom-api/'
 export const baseApi = `https://store-api.www.bash.com${customPath}`
 export const baseApiQA = `https://store-api.staging.tfglabs.dev${customPath}`
 export const accountName = 'thefoschini'
+export const appHomeProd = 'com.tfglabs.manhattan.beta://home'
+export const appHomeStaging = 'com.bash://home'

--- a/react/utils/constants.ts
+++ b/react/utils/constants.ts
@@ -2,5 +2,5 @@ export const customPath = '/custom-api/'
 export const baseApi = `https://store-api.www.bash.com${customPath}`
 export const baseApiQA = `https://store-api.staging.tfglabs.dev${customPath}`
 export const accountName = 'thefoschini'
-export const appHomeProd = 'com.tfglabs.manhattan.beta://home'
-export const appHomeStaging = 'com.bash://home'
+export const appHomeStaging = 'com.tfglabs.manhattan.beta://home'
+export const appHomeProd = 'com.bash://home'


### PR DESCRIPTION
### What problem is this solving?
Continue shopping button needs to be enabled to navigate to app home

#### How it works

#### How to test it?
Once is_app cookie is added, click on continue shopping button and check network tab for app doc replacement
[Workspace](https://bpf3361--thefoschini.myvtex.com/checkout/orderPlaced/?og=B5979916)

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil
<img width="1392" alt="Screenshot 2024-08-19 at 11 58 42" src="https://github.com/user-attachments/assets/47b0a1fa-00a4-469d-b0e1-ab98334fae5b">


### Related to / Depends on

#### How does this PR make you feel? :link:
![]()
