### PR TITLE
[BPF-3438] Update EventsAnalytics for purchase event (web and app)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,6 @@
     }
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.15.23] - 2024-09-09
+
 ## [2.15.22] - 2024-09-03
 
 ## [2.15.21] - 2024-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.15.24] - 2024-09-09
+
 ## [2.15.23] - 2024-09-09
 
 ## [2.15.22] - 2024-09-03

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "thefoschini",
   "name": "order-placed",
-  "version": "2.15.23",
+  "version": "2.15.24",
   "title": "Order Placed",
   "description": "",
   "registries": ["smartcheckout"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,10 @@
 {
   "vendor": "thefoschini",
   "name": "order-placed",
-  "version": "2.15.22",
+  "version": "2.15.23",
   "title": "Order Placed",
   "description": "",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -19,6 +19,7 @@ import useGetNotices from './hooks/useGetNotices'
 import Notice from './components/Notice'
 import './styles.css'
 import { getCookie } from './utils/functions'
+import { gaMeasurementId } from './utils'
 
 interface OrderGroupData {
   orderGroup: OrderGroup
@@ -47,6 +48,35 @@ const OrderPlaced: FC = () => {
   useEffect(() => {
     const isAppCookie = getCookie('is_app')
     setIsApp(!!isAppCookie)
+  }, [])
+
+  // Google Analytics Setup
+  useEffect(() => {
+    const handleGtagInitialization = () => {
+      if (typeof window !== 'undefined' && window.dataLayer && !window.gtag) {
+        window.gtag = function () {
+          // eslint-disable-next-line prefer-rest-params
+          window.dataLayer.push(arguments)
+        }
+        window.gtag('js', new Date())
+        window.gtag('config', gaMeasurementId, {
+          user_properties: {
+            platform_type: document.cookie.includes('is_app=true')
+              ? 'App'
+              : 'Web',
+          },
+        })
+      }
+
+      window.dispatchEvent(new Event('gtag_loaded'))
+    }
+
+    handleGtagInitialization()
+    window.addEventListener('gtm.js', handleGtagInitialization)
+
+    return () => {
+      window.removeEventListener('gtm.js', handleGtagInitialization)
+    }
   }, [])
 
   const { customerEmail, customerEmailLoading } = useGetCustomerEmail(

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -45,6 +45,25 @@ const OrderPlaced: FC = () => {
     },
   })
 
+  const handleGtagInitialization = () => {
+    if (typeof window !== 'undefined' && window.dataLayer && !window.gtag) {
+      window.gtag = function () {
+        // eslint-disable-next-line prefer-rest-params
+        window.dataLayer.push(arguments)
+      }
+      window.gtag('js', new Date())
+      window.gtag('config', gaMeasurementId, {
+        user_properties: {
+          platform_type: document.cookie.includes('is_app=true')
+            ? 'App'
+            : 'Web',
+        },
+      })
+    }
+
+    window.dispatchEvent(new Event('gtag_loaded'))
+  }
+
   useEffect(() => {
     const isAppCookie = getCookie('is_app')
     setIsApp(!!isAppCookie)
@@ -52,25 +71,6 @@ const OrderPlaced: FC = () => {
 
   // Google Analytics Setup
   useEffect(() => {
-    const handleGtagInitialization = () => {
-      if (typeof window !== 'undefined' && window.dataLayer && !window.gtag) {
-        window.gtag = function () {
-          // eslint-disable-next-line prefer-rest-params
-          window.dataLayer.push(arguments)
-        }
-        window.gtag('js', new Date())
-        window.gtag('config', gaMeasurementId, {
-          user_properties: {
-            platform_type: document.cookie.includes('is_app=true')
-              ? 'App'
-              : 'Web',
-          },
-        })
-      }
-
-      window.dispatchEvent(new Event('gtag_loaded'))
-    }
-
     handleGtagInitialization()
     window.addEventListener('gtm.js', handleGtagInitialization)
 

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "thefoschini.order-details": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details",
-    "thefoschini.order-placed": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed",
+    "thefoschini.order-placed": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.23/public/@types/thefoschini.order-placed",
     "typescript": "3.9.7",
     "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.6/public/@types/vtex.address-form",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "thefoschini.order-details": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details",
-    "thefoschini.order-placed": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.21/public/@types/thefoschini.order-placed",
+    "thefoschini.order-placed": "https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed",
     "typescript": "3.9.7",
     "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.6/public/@types/vtex.address-form",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "thefoschini.order-details": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details",
-    "thefoschini.order-placed": "https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed",
+    "thefoschini.order-placed": "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed",
     "typescript": "3.9.7",
     "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.24.6/public/@types/vtex.address-form",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",

--- a/react/utils/constants.ts
+++ b/react/utils/constants.ts
@@ -4,3 +4,4 @@ export const baseApiQA = `https://store-api.staging.tfglabs.dev${customPath}`
 export const accountName = 'thefoschini'
 export const appHomeStaging = 'com.tfglabs.manhattan.beta://home'
 export const appHomeProd = 'com.bash://home'
+export const gaMeasurementId = 'G-198NPKWM95'

--- a/react/utils/events/EventAnalytics.ts
+++ b/react/utils/events/EventAnalytics.ts
@@ -29,7 +29,6 @@ class EventAnalytics {
   }
 
   public trackEvent(event: any) {
-    console.info('TRACK EVENT', event)
     this.buffer.push(event)
     if (this.buffer.length === 1) {
       this.flush()
@@ -104,6 +103,7 @@ class EventAnalytics {
     this.buffer = []
 
     const cookieData = this.getAppAnalyticsCookieData()
+
     const webData = await this.getWebTrackingConfig()
 
     const body = JSON.stringify({

--- a/react/utils/events/index.ts
+++ b/react/utils/events/index.ts
@@ -47,6 +47,7 @@ const getUserId = (
  * @description Get the customer items from ga_data cookie
  * @returns array of items for Google ecommerce events
  */
+
 const getCustomerItems = () => {
   const customerItems = getCookieValue('ga_data')
   if (!customerItems) return []
@@ -150,6 +151,8 @@ export const pushPayEvent = (
     transformedEventData.event = 'gaEvent'
   }
 
+  console.info({ transformedEventData })
+
   // If the event is not a GA event, send it to the mobile analytics endpoint.
   // After renaming events due to popular demand, we discovered that GA Web
   // does not like events that are not named 'gaEvent'.
@@ -166,6 +169,8 @@ export const pushPayEvent = (
         }, {}),
       },
     }
+
+    console.info({ eventForAnalytics })
 
     analytics.trackEvent(eventForAnalytics)
 

--- a/react/utils/events/index.ts
+++ b/react/utils/events/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import MobileAnalytics from './MobileAnalytics'
+import EventAnalytics from './EventAnalytics'
 import { DataLayerObject } from './types'
 
 export function getCookieValue(name: string) {
@@ -39,7 +39,7 @@ const getUserId = (
 
   const { userId, sub } = data
 
-  return { userId, sub }
+  return { userId, sub: String(sub)?.split('@')[0] || undefined }
 }
 
 /**
@@ -93,12 +93,24 @@ const pushToDataLayer = (
   window.dataLayer?.push(forDataLayer)
 }
 
+/**
+ * truncateString
+ * Truncate a string to a specified length.
+ * @param str
+ * @param maxLength
+ * @returns string
+ */
+export const truncateString = (str: string, maxLength = 100): string => {
+  if (!str) return ''
+  return str.length > maxLength ? `${str.slice(0, maxLength - 3)}...` : str
+}
+
 export const pushPayEvent = (
   eventData: DataLayerObject,
   account: 'thefoschini' | 'thefoschiniqa' = 'thefoschini'
 ) => {
   if (!eventData) return
-  const analytics = new MobileAnalytics(3000, 3, account)
+  const analytics = new EventAnalytics(3000, 3, account)
 
   const isApp = document?.cookie.includes('is_app=true')
   let transformedEventData: { [key: string]: string | object } = {
@@ -107,6 +119,8 @@ export const pushPayEvent = (
     eventLabel: eventData.event_label || 'Pay_Event',
     eventDescription: eventData.event_description || 'Pay Event',
   }
+
+  eventData.event_description = truncateString(eventData.event_description, 100)
 
   if (eventData.event_detail) {
     transformedEventData.eventDescription = JSON.stringify(
@@ -129,15 +143,18 @@ export const pushPayEvent = (
         ...eventData,
         currency: 'ZAR',
         items,
-        user_id: getUserId(account)?.userId || undefined,
+        user_id: getUserId()?.sub ?? undefined,
       },
     }
   } else {
     transformedEventData.event = 'gaEvent'
   }
 
-  if (isApp) {
-    const eventForMobile = {
+  // If the event is not a GA event, send it to the mobile analytics endpoint.
+  // After renaming events due to popular demand, we discovered that GA Web
+  // does not like events that are not named 'gaEvent'.
+  if (isApp || transformedEventData.event !== 'gaEvent') {
+    const eventForAnalytics = {
       name: transformedEventData.event,
       params: {
         ...((transformedEventData.ecommerce as object) || {}),
@@ -150,7 +167,7 @@ export const pushPayEvent = (
       },
     }
 
-    analytics.trackEvent(eventForMobile)
+    analytics.trackEvent(eventForAnalytics)
 
     // If we're on app, don't send the GTM event as well.
     if (isApp) return

--- a/react/utils/events/index.ts
+++ b/react/utils/events/index.ts
@@ -151,8 +151,6 @@ export const pushPayEvent = (
     transformedEventData.event = 'gaEvent'
   }
 
-  console.info({ transformedEventData })
-
   // If the event is not a GA event, send it to the mobile analytics endpoint.
   // After renaming events due to popular demand, we discovered that GA Web
   // does not like events that are not named 'gaEvent'.
@@ -169,8 +167,6 @@ export const pushPayEvent = (
         }, {}),
       },
     }
-
-    console.info({ eventForAnalytics })
 
     analytics.trackEvent(eventForAnalytics)
 

--- a/react/utils/events/types.d.ts
+++ b/react/utils/events/types.d.ts
@@ -1,6 +1,7 @@
 declare global {
   interface Window {
     dataLayer: any[]
+    gtag: (...args: any[]) => void
   }
 }
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4911,9 +4911,9 @@ test-exclude@^5.2.3:
   version "1.9.15"
   resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details#69e4de12e6248a60353776356ffc860bbdbc8c8c"
 
-"thefoschini.order-placed@http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed":
-  version "2.15.22"
-  resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed#99af8e2fe9a7e18d70ac29a45e90ccbb20ccbf8b"
+"thefoschini.order-placed@http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.23/public/@types/thefoschini.order-placed":
+  version "2.15.23"
+  resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.23/public/@types/thefoschini.order-placed#41484cac8a7b0cb195b783b20edc2329347c72e9"
 
 throat@^4.0.0:
   version "4.1.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4911,9 +4911,9 @@ test-exclude@^5.2.3:
   version "1.9.15"
   resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details#69e4de12e6248a60353776356ffc860bbdbc8c8c"
 
-"thefoschini.order-placed@http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.21/public/@types/thefoschini.order-placed":
-  version "2.15.21"
-  resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.21/public/@types/thefoschini.order-placed#29b7ff8a73f558a0165e4dec465391d060087ab5"
+"thefoschini.order-placed@https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed":
+  version "2.15.22"
+  resolved "https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed#f59b8a8447130142a1dcdf5cbe69570e9e90bef6"
 
 throat@^4.0.0:
   version "4.1.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4911,9 +4911,9 @@ test-exclude@^5.2.3:
   version "1.9.15"
   resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-details@1.9.15/public/@types/thefoschini.order-details#69e4de12e6248a60353776356ffc860bbdbc8c8c"
 
-"thefoschini.order-placed@https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed":
+"thefoschini.order-placed@http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed":
   version "2.15.22"
-  resolved "https://bpf3427--thefoschini.myvtex.com/_v/private/typings/linked/v1/thefoschini.order-placed@2.15.22+build1725628811/public/@types/thefoschini.order-placed#f59b8a8447130142a1dcdf5cbe69570e9e90bef6"
+  resolved "http://thefoschini.vtexassets.com/_v/public/typings/v1/thefoschini.order-placed@2.15.22/public/@types/thefoschini.order-placed#99af8e2fe9a7e18d70ac29a45e90ccbb20ccbf8b"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
### What problem is this solving?
Update purchase event for orderPlaced

#### How it works
- Replace MobileAnalytics with the new EventsAnalytics used on BashPay (applies to both web and app)

#### How to test it?
Needs to be tested on a Prod URL:
- add `workspace=preorderplaced` to your URL
https://bash.com/checkout/orderPlaced/?og=B7467377&workspace=preorderplaced

![image](https://github.com/user-attachments/assets/606a8288-10bf-4ca7-a59f-3e064ddc15d4)

### Related to / Depends on
https://tfginfotec.atlassian.net/browse/BPF-3438

#### How does this PR make you feel? :link:
![]()
